### PR TITLE
feat: Customizable MQTT Topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ MQTT_HOSTNAME //default is localhost
 MQTT_PORT //default is 1883
 MQTT_USERNAME //default is empty
 MQTT_PASSWORD //default is empty
+MQTT_TOPICS //default is "tele/+/+, stat/+/+". If you're using deeper topics, you can set as "tele/#, stat/#"
 PROMETHEUS_EXPORTER_PORT //listening port. Default is 9092
 REMOVE_WHEN_INACTIVE_MINUTES //optional. Default is 1. If the device is inactive for more than 1 minute, it will be removed from the list of active devices
 ```

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,7 +22,7 @@ func main() {
 	}
 
 	e := engine.NewEngine(mqttClient, pm)
-	e.Subscribe([]string{"tele/+/+", "stat/+/+"})
+	e.Subscribe(v.mqttTopics)
 
 	s := server.NewServer(v.serverPort, m)
 	s.Start()

--- a/cmd/vars.go
+++ b/cmd/vars.go
@@ -4,11 +4,13 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"strings"
 )
 
 type vars struct {
 	mqttHost, mqttUsername, mqttPassword            string
 	mqttPort, serverPort, removeWhenInactiveMinutes int
+	mqttTopics                                      []string
 }
 
 func ReadEnv() *vars {
@@ -31,6 +33,7 @@ func ReadEnv() *vars {
 		log.Fatalf("can't parse provided timeout: %s", err)
 	}
 	v.removeWhenInactiveMinutes = removeWhenInactiveMinutes
+	v.mqttTopics = orDefaultList(os.Getenv("MQTT_TOPICS"), "tele/+/+, stat/+/+")
 	return v
 }
 
@@ -39,4 +42,20 @@ func orDefault(value string, def string) string {
 		return def
 	}
 	return value
+}
+
+// read env variable, split per comma, trim the values, and return them as a list of strings
+func orDefaultList(value string, def string) []string {
+	if value == "" {
+		return splitAndTrim(def)
+	}
+	return splitAndTrim(value)
+}
+
+func splitAndTrim(value string) []string {
+	s := strings.Split(value, ",")
+	for i, v := range s {
+		s[i] = strings.TrimSpace(v)
+	}
+	return s
 }


### PR DESCRIPTION
WHAT:

Transform hard codded topics from code to environment variable `MQTT_TOPICS`.

WHY:

I'm not using the default MQTT configuration of Tasmota.

I rather have "partitions" about the rooms of my house. I mean:

Instead of `tele/my-device` I do `tele/living_room/my-device`.

So, I could set the MQTT_TOPICS to `"stat/#, tele/#"` and capture everything, or `"stat/living_room/#, tele/living_room/#"` to capture msgs just from the `living_room` "partition".