### PR TITLE
Bugfix for invalid character '-' in topic names

### DIFF
--- a/pkg/metrics/extractor.go
+++ b/pkg/metrics/extractor.go
@@ -8,6 +8,7 @@ import (
 
 var matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
 var matchAllCap = regexp.MustCompile("([a-z0-9])([A-Z])")
+var matchInvalidChar = regexp.MustCompile("[-]")
 
 func Extract(message []byte) map[string]any {
 	incoming := map[string]any{}
@@ -44,5 +45,6 @@ func normalize(incoming map[string]any) map[string]any {
 func toSnakeCase(camelCase string) string {
 	snake := matchFirstCap.ReplaceAllString(camelCase, "${1}_${2}")
 	snake = matchAllCap.ReplaceAllString(snake, "${1}_${2}")
-	return strings.ToLower(snake)
+	snake = matchInvalidChar.ReplaceAllString(snake, "_")
+ 	return strings.ToLower(snake)
 }

--- a/pkg/metrics/extractor_test.go
+++ b/pkg/metrics/extractor_test.go
@@ -16,6 +16,7 @@ func TestExtract(t *testing.T) {
 {
   "Status": {
     "DeviceName": "nas_outlet",
+    "DeviceName-alias": "outlet",
     "Topic": "nas-outlet",
     "SaveData": 1
   },
@@ -40,4 +41,9 @@ func TestExtract(t *testing.T) {
 	if extracted["status_device_name"] != "nas_outlet" {
 		t.Fatalf("wrong value: %s", extracted["status_device_name"])
 	}
+
+	if extracted["status_device_name_alias"] != "outlet" {
+		t.Fatalf("wrong value: %s", extracted["status_device_name_alias"])
+	}
+
 }


### PR DESCRIPTION
Tasmota numbers multiple temperature sensors as e.g. DS18B20-1, DS18B20-2 and so on within the json data which broke the exporter