### PR TITLE
support ARCH build argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 FROM golang:1.18.4 AS builder
+
+ARG ARCH=amd64
+
 WORKDIR /tasmota-exporter/
 COPY . .
 RUN go mod download
-RUN CGO_ENABLED=0 GOOS=linux go build -o app ./cmd
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$ARCH go build -o app ./cmd
 
 FROM alpine:latest
 WORKDIR /root/


### PR DESCRIPTION
Hi, this is a small PR to support your exporter also on other CPU architectures than AMD64.
I have successfully cross compiled your project to ARM64. It work nicely now on a raspberry pi.

With the ARCH build argument, the project can be easily cross compiled for other platforms. 
the build argument translates to GOARCH. 

I'm not familiar with Drone CI, but it should be easy to build containers for linux/amd64, linux/arm64 ... and push them docker hub.

Docker hub supports multi architectures. On the command line you have to add `--platform linux/*arch*`. 

For linux/amd64:
```
docker build --build-arg ARCH=amd64 . --platform linux/amd64 -t  eugenezadyra/tasmota-exporter --no-cache
``` 

And for linux/arm64:
```
docker build --build-arg ARCH=arm64 . --platform linux/arm64 -t  eugenezadyra/tasmota-exporter --no-cache
``` 

arm 32bit (GOARCH 'arm') would probably be another good choice. darwin/amd64 and darwin/arm64 probably also.