### PR TITLE
Make the status update interval configurable using environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea/
 .vscode/
+.env
+tasmota-exporter

--- a/README.md
+++ b/README.md
@@ -32,9 +32,17 @@ MQTT_HOSTNAME //default is localhost
 MQTT_PORT //default is 1883
 MQTT_USERNAME //default is empty
 MQTT_PASSWORD //default is empty
+MQTT_CLIENT_ID //default is prometheus_tasmota_exporter
 MQTT_TOPICS //default is "tele/+/+, stat/+/+". If you're using deeper topics, you can set as "tele/#, stat/#"
 PROMETHEUS_EXPORTER_PORT //listening port. Default is 9092
 REMOVE_WHEN_INACTIVE_MINUTES //optional. Default is 1. If the device is inactive for more than 1 minute, it will be removed from the list of active devices
+STATUS_UPDATE_SECONDS //optional. Default is 5. This is how often a status update will be requested
+```
+
+You could also put the variables in a .env file and do the following:
+```
+source .env
+export $(cut -d= -f1 .env)
 ```
 
 Then run it using:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,9 +1,10 @@
 package main
 
 import (
+	"log"
+
 	"github.com/dyrkin/tasmota-exporter/pkg/engine"
 	"github.com/dyrkin/tasmota-exporter/pkg/metrics"
-	"log"
 
 	"github.com/dyrkin/tasmota-exporter/pkg/mqttclient"
 	"github.com/dyrkin/tasmota-exporter/pkg/server"
@@ -16,12 +17,12 @@ func main() {
 	c := metrics.NewCleaner(m, v.removeWhenInactiveMinutes)
 	c.Start()
 
-	mqttClient := mqttclient.NewMqttClient(v.mqttHost, v.mqttPort, v.mqttUsername, v.mqttPassword)
+	mqttClient := mqttclient.NewMqttClient(v.mqttHost, v.mqttPort, v.mqttUsername, v.mqttPassword, v.mqttClientId)
 	if err := mqttClient.Connect(); err != nil {
 		log.Fatalf("can't connect to mqtt broker: %s", err)
 	}
 
-	e := engine.NewEngine(mqttClient, pm)
+	e := engine.NewEngine(mqttClient, pm, v.statusUpdateInterval)
 	e.Subscribe(v.mqttTopics)
 
 	s := server.NewServer(v.serverPort, m)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,7 +22,7 @@ func main() {
 		log.Fatalf("can't connect to mqtt broker: %s", err)
 	}
 
-	e := engine.NewEngine(mqttClient, pm, v.statusUpdateInterval)
+	e := engine.NewEngine(mqttClient, pm, v.statusUpdateSeconds)
 	e.Subscribe(v.mqttTopics)
 
 	s := server.NewServer(v.serverPort, m)

--- a/cmd/vars.go
+++ b/cmd/vars.go
@@ -8,9 +8,9 @@ import (
 )
 
 type vars struct {
-	mqttHost, mqttUsername, mqttPassword, mqttClientId                    string
-	mqttPort, serverPort, removeWhenInactiveMinutes, statusUpdateInterval int
-	mqttTopics                                                            []string
+	mqttHost, mqttUsername, mqttPassword, mqttClientId                   string
+	mqttPort, serverPort, removeWhenInactiveMinutes, statusUpdateSeconds int
+	mqttTopics                                                           []string
 }
 
 func ReadEnv() *vars {
@@ -35,11 +35,11 @@ func ReadEnv() *vars {
 	}
 	v.removeWhenInactiveMinutes = removeWhenInactiveMinutes
 	v.mqttTopics = orDefaultList(os.Getenv("MQTT_TOPICS"), "tele/+/+, stat/+/+")
-	statusUpdateInterval, err := strconv.Atoi(orDefault(os.Getenv("STATUS_UPDATE_SECONDS"), "5"))
+	statusUpdateSeconds, err := strconv.Atoi(orDefault(os.Getenv("STATUS_UPDATE_SECONDS"), "5"))
 	if err != nil {
 		log.Fatalf("can't parse provided status update interval: %s", err)
 	}
-	v.statusUpdateInterval = statusUpdateInterval
+	v.statusUpdateSeconds = statusUpdateSeconds
 	return v
 }
 

--- a/cmd/vars.go
+++ b/cmd/vars.go
@@ -8,9 +8,9 @@ import (
 )
 
 type vars struct {
-	mqttHost, mqttUsername, mqttPassword            string
-	mqttPort, serverPort, removeWhenInactiveMinutes int
-	mqttTopics                                      []string
+	mqttHost, mqttUsername, mqttPassword, mqttClientId                    string
+	mqttPort, serverPort, removeWhenInactiveMinutes, statusUpdateInterval int
+	mqttTopics                                                            []string
 }
 
 func ReadEnv() *vars {
@@ -23,6 +23,7 @@ func ReadEnv() *vars {
 	v.mqttPort = mqttPort
 	v.mqttUsername = orDefault(os.Getenv("MQTT_USERNAME"), "")
 	v.mqttPassword = orDefault(os.Getenv("MQTT_PASSWORD"), "")
+	v.mqttClientId = orDefault(os.Getenv("MQTT_CLIENT_ID"), "prometheus_tasmota_exporter")
 	serverPort, err := strconv.Atoi(orDefault(os.Getenv("PROMETHEUS_EXPORTER_PORT"), "9092"))
 	if err != nil {
 		log.Fatalf("can't parse provided server port: %s", err)
@@ -34,6 +35,11 @@ func ReadEnv() *vars {
 	}
 	v.removeWhenInactiveMinutes = removeWhenInactiveMinutes
 	v.mqttTopics = orDefaultList(os.Getenv("MQTT_TOPICS"), "tele/+/+, stat/+/+")
+	statusUpdateInterval, err := strconv.Atoi(orDefault(os.Getenv("STATUS_UPDATE_SECONDS"), "5"))
+	if err != nil {
+		log.Fatalf("can't parse provided status update interval: %s", err)
+	}
+	v.statusUpdateInterval = statusUpdateInterval
 	return v
 }
 

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -1,24 +1,26 @@
 package engine
 
 import (
-	"github.com/dyrkin/tasmota-exporter/pkg/metrics"
-	"github.com/dyrkin/tasmota-exporter/pkg/mqttclient"
-	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"log"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/dyrkin/tasmota-exporter/pkg/metrics"
+	"github.com/dyrkin/tasmota-exporter/pkg/mqttclient"
+	mqtt "github.com/eclipse/paho.mqtt.golang"
 )
 
 type Engine struct {
-	scheduled    map[string]any
-	lock         *sync.Mutex
-	mqttClient   *mqttclient.MqttClient
-	plainMetrics *metrics.PlainMetrics
+	scheduled            map[string]any
+	lock                 *sync.Mutex
+	mqttClient           *mqttclient.MqttClient
+	plainMetrics         *metrics.PlainMetrics
+	statusUpdateInterval int
 }
 
-func NewEngine(mqttClient *mqttclient.MqttClient, pm *metrics.PlainMetrics) *Engine {
-	return &Engine{map[string]any{}, &sync.Mutex{}, mqttClient, pm}
+func NewEngine(mqttClient *mqttclient.MqttClient, pm *metrics.PlainMetrics, statusUpdateInterval int) *Engine {
+	return &Engine{map[string]any{}, &sync.Mutex{}, mqttClient, pm, statusUpdateInterval}
 }
 
 func (e *Engine) Subscribe(mqttListenTopics []string) {
@@ -46,7 +48,7 @@ func (e *Engine) scheduleStatusCommand(topic string) {
 		if _, ok := e.scheduled[source]; !ok {
 			log.Printf("scheduling status updates for: %s", source)
 			e.scheduled[source] = true
-			ticker := time.NewTicker(5 * time.Second)
+			ticker := time.NewTicker(time.Duration(e.statusUpdateInterval) * time.Second)
 			go func() {
 				for {
 					select {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -12,15 +12,15 @@ import (
 )
 
 type Engine struct {
-	scheduled            map[string]any
-	lock                 *sync.Mutex
-	mqttClient           *mqttclient.MqttClient
-	plainMetrics         *metrics.PlainMetrics
-	statusUpdateInterval int
+	scheduled           map[string]any
+	lock                *sync.Mutex
+	mqttClient          *mqttclient.MqttClient
+	plainMetrics        *metrics.PlainMetrics
+	statusUpdateSeconds int
 }
 
-func NewEngine(mqttClient *mqttclient.MqttClient, pm *metrics.PlainMetrics, statusUpdateInterval int) *Engine {
-	return &Engine{map[string]any{}, &sync.Mutex{}, mqttClient, pm, statusUpdateInterval}
+func NewEngine(mqttClient *mqttclient.MqttClient, pm *metrics.PlainMetrics, statusUpdateSeconds int) *Engine {
+	return &Engine{map[string]any{}, &sync.Mutex{}, mqttClient, pm, statusUpdateSeconds}
 }
 
 func (e *Engine) Subscribe(mqttListenTopics []string) {
@@ -46,9 +46,9 @@ func (e *Engine) scheduleStatusCommand(topic string) {
 		e.lock.Lock()
 		defer e.lock.Unlock()
 		if _, ok := e.scheduled[source]; !ok {
-			log.Printf("scheduling status updates for: %s", source)
+			log.Printf("scheduling %d second status updates for: %s", e.statusUpdateSeconds, source)
 			e.scheduled[source] = true
-			ticker := time.NewTicker(time.Duration(e.statusUpdateInterval) * time.Second)
+			ticker := time.NewTicker(time.Duration(e.statusUpdateSeconds) * time.Second)
 			go func() {
 				for {
 					select {

--- a/pkg/mqttclient/mqttclient.go
+++ b/pkg/mqttclient/mqttclient.go
@@ -12,11 +12,11 @@ type MqttClient struct {
 	c mqtt.Client
 }
 
-func NewMqttClient(host string, port int, user, password string) *MqttClient {
+func NewMqttClient(host string, port int, user, password string, client_id string) *MqttClient {
 	mqttClient := &MqttClient{}
 	options := mqtt.NewClientOptions()
 	options.AddBroker(fmt.Sprintf("tcp://%s:%d", host, port))
-	options.SetClientID("prometheus_tasmota_exporter")
+	options.SetClientID(client_id)
 	options.SetUsername(user)
 	options.SetPassword(password)
 	options.SetCleanSession(false)


### PR DESCRIPTION
Added in environment variable `STATUS_UPDATE_SECONDS` to adjust how often status updates are requested - was hardcoded to 5 seconds before. 

Other minor edits to make it easier to dev with 
- Environment variables in a file
- Configurable MQTT_CLIENT_ID