### PR TITLE
logging: switch to slog package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.4 AS builder
+FROM golang:1.21 AS builder
 
 ARG ARCH=amd64
 

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,4 +1,4 @@
-FROM golang:1.18.4 AS builder
+FROM golang:1.21 AS builder
 
 ARG ARCH=arm64
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ MQTT_TOPICS //default is "tele/+/+, stat/+/+". If you're using deeper topics, yo
 PROMETHEUS_EXPORTER_PORT //listening port. Default is 9092
 REMOVE_WHEN_INACTIVE_MINUTES //optional. Default is 1. If the device is inactive for more than 1 minute, it will be removed from the list of active devices
 STATUS_UPDATE_SECONDS //optional. Default is 5. This is how often a status update will be requested
+LOG_LEVEL // default is info. Severity level for log output. Possible values: debug, info, warn, error
 ```
 
 You could also put the variables in a .env file and do the following:

--- a/cmd/vars.go
+++ b/cmd/vars.go
@@ -1,7 +1,8 @@
 package main
 
 import (
-	"log"
+	"fmt"
+	"log/slog"
 	"os"
 	"strconv"
 	"strings"
@@ -13,12 +14,12 @@ type vars struct {
 	mqttTopics                                                           []string
 }
 
-func ReadEnv() *vars {
+func ReadEnv() (*vars, error) {
 	v := &vars{}
 	v.mqttHost = orDefault(os.Getenv("MQTT_HOSTNAME"), "localhost")
 	mqttPort, err := strconv.Atoi(orDefault(os.Getenv("MQTT_PORT"), "1883"))
 	if err != nil {
-		log.Fatalf("can't parse provided mqtt port: %s", err)
+		return nil, fmt.Errorf("can't parse provided mqtt port: %s", err)
 	}
 	v.mqttPort = mqttPort
 	v.mqttUsername = orDefault(os.Getenv("MQTT_USERNAME"), "")
@@ -26,21 +27,30 @@ func ReadEnv() *vars {
 	v.mqttClientId = orDefault(os.Getenv("MQTT_CLIENT_ID"), "prometheus_tasmota_exporter")
 	serverPort, err := strconv.Atoi(orDefault(os.Getenv("PROMETHEUS_EXPORTER_PORT"), "9092"))
 	if err != nil {
-		log.Fatalf("can't parse provided server port: %s", err)
+		return nil, fmt.Errorf("can't parse provided server port: %s", err)
 	}
 	v.serverPort = serverPort
 	removeWhenInactiveMinutes, err := strconv.Atoi(orDefault(os.Getenv("REMOVE_WHEN_INACTIVE_MINUTES"), "1"))
 	if err != nil {
-		log.Fatalf("can't parse provided timeout: %s", err)
+		return nil, fmt.Errorf("can't parse provided timeout: %s", err)
 	}
 	v.removeWhenInactiveMinutes = removeWhenInactiveMinutes
 	v.mqttTopics = orDefaultList(os.Getenv("MQTT_TOPICS"), "tele/+/+, stat/+/+")
 	statusUpdateSeconds, err := strconv.Atoi(orDefault(os.Getenv("STATUS_UPDATE_SECONDS"), "5"))
 	if err != nil {
-		log.Fatalf("can't parse provided status update interval: %s", err)
+		return nil, fmt.Errorf("can't parse provided status update interval: %s", err)
 	}
 	v.statusUpdateSeconds = statusUpdateSeconds
-	return v
+
+	logLevelStr := orDefault(os.Getenv("LOG_LEVEL"), "info")
+	var logLevel slog.Level
+	if err := logLevel.UnmarshalText([]byte(logLevelStr)); err != nil {
+		return nil, fmt.Errorf("can't parse provided log level %q: %s", logLevelStr, err)
+	}
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: logLevel,
+	})))
+	return v, nil
 }
 
 func orDefault(value string, def string) string {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dyrkin/tasmota-exporter
 
-go 1.18
+go 1.21
 
 require github.com/prometheus/client_golang v1.12.2
 

--- a/pkg/metrics/cleaner.go
+++ b/pkg/metrics/cleaner.go
@@ -1,7 +1,7 @@
 package metrics
 
 import (
-	"log"
+	"log/slog"
 	"time"
 )
 
@@ -34,12 +34,12 @@ func (c *Cleaner) Start() {
 							}
 						}
 						delete(c.m.pm.metrics, source)
-						log.Println("removed inactive source: " + source)
+						slog.Info("removed inactive source", "source", source)
 					}
 				}
 				c.m.pm.lock.Unlock()
 			}
 		}
 	}()
-	log.Println("scheduled metrics cleanup")
+	slog.Debug("scheduled metrics cleanup")
 }

--- a/pkg/metrics/plainmetrics.go
+++ b/pkg/metrics/plainmetrics.go
@@ -1,7 +1,7 @@
 package metrics
 
 import (
-	"log"
+	"log/slog"
 	"strings"
 	"sync"
 	"time"
@@ -26,7 +26,7 @@ func (m *PlainMetrics) Update(topic string, data map[string]any) {
 	if len(data) > 0 {
 		segments := strings.Split(topic, "/")
 		source := strings.Join(segments[:len(segments)-1], "/")
-		log.Println("received update for: " + source)
+		slog.Debug("received update", "source", source)
 		m.lock.Lock()
 		defer m.lock.Unlock()
 

--- a/pkg/mqttclient/mqttclient.go
+++ b/pkg/mqttclient/mqttclient.go
@@ -2,7 +2,7 @@ package mqttclient
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"syscall"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
@@ -53,12 +53,11 @@ func (mc *MqttClient) SendCommand(topic, payload string) error {
 	return nil
 }
 
-func (mc *MqttClient) connectionHandler(_ mqtt.Client) {
-	log.Printf("mqtt connected")
+func (mc *MqttClient) connectionHandler(c mqtt.Client) {
+	slog.Info("mqtt connected")
 }
 
 func (mc *MqttClient) connectionLostHandler(_ mqtt.Client, err error) {
-	log.Printf("mqtt disconnected. reason: %s", err)
-	log.Println("exiting...")
+	slog.Error("mqtt disconnected, exiting.", "reason", err)
 	syscall.Exit(1)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,12 +1,13 @@
 package server
 
 import (
-	"log"
+	"log/slog"
 	"net/http"
 	"strconv"
 
-	"github.com/dyrkin/tasmota-exporter/pkg/metrics"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/dyrkin/tasmota-exporter/pkg/metrics"
 )
 
 type Server struct {
@@ -34,11 +35,7 @@ func NewServer(port int, metrics *metrics.Metrics) *Server {
 	return s
 }
 
-func (s *Server) Start() {
-	log.Printf("Started listening on: %d", s.port)
-
-	err := s.httpServer.ListenAndServe()
-	if err != nil {
-		log.Fatalf("Failed to start server: %v", err)
-	}
+func (s *Server) Start() error {
+	slog.Info("Started listening", "port", s.port)
+	return s.httpServer.ListenAndServe()
 }


### PR DESCRIPTION
The standard log package does not provide facilities to implement different log levels. However, this tool outputs a lot of debug information, cluttering the logs in a production environment.

Switch to the log/slog package, introduced in Go 1.21, which implements structured logging and log levels in the Go standard library.

The log level is "info" by default, and configurable by the LOG_LEVEL environment variable.

Fixes #6.