### PR TITLE
Added device IP address to prometheus metrics.

### DIFF
--- a/pkg/metrics/cleaner.go
+++ b/pkg/metrics/cleaner.go
@@ -25,11 +25,12 @@ func (c *Cleaner) Start() {
 					if time.Since(sourceMetrics.lastAccessed) > time.Duration(c.removeWhenInactiveMinutes)*time.Minute {
 						statusTopic, topicExists := sourceMetrics.Metrics["status_topic"].(string)
 						statusNetHostname, hostnameExists := sourceMetrics.Metrics["status_net_hostname"].(string)
+						statusNetIpAddress, ipAddressExists := sourceMetrics.Metrics["status_net_ip_address"].(string)
 						statusDeviceName, deviceNameExists := sourceMetrics.Metrics["status_device_name"].(string)
 						for pmk := range sourceMetrics.Metrics {
-							if topicExists && hostnameExists && deviceNameExists {
+							if topicExists && hostnameExists && ipAddressExists && deviceNameExists {
 								if gauge, ok := c.m.gauges[pmk]; ok {
-									gauge.DeleteLabelValues(source, statusTopic, statusNetHostname, statusDeviceName)
+									gauge.DeleteLabelValues(source, statusTopic, statusNetHostname, statusNetIpAddress, statusDeviceName)
 								}
 							}
 						}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -19,20 +19,21 @@ func (m *Metrics) Refresh() {
 	for source, sourceMetrics := range m.pm.metrics {
 		statusTopic, topicExists := sourceMetrics.Metrics["status_topic"].(string)
 		statusNetHostname, hostnameExists := sourceMetrics.Metrics["status_net_hostname"].(string)
+		statusNetIpAddress, ipAddressExists := sourceMetrics.Metrics["status_net_ip_address"].(string)
 		statusDeviceName, deviceNameExists := sourceMetrics.Metrics["status_device_name"].(string)
 		for pmk, pmv := range sourceMetrics.Metrics {
-			if float, ok := pmv.(float64); ok && topicExists && hostnameExists && deviceNameExists {
+			if float, ok := pmv.(float64); ok && topicExists && hostnameExists && ipAddressExists && deviceNameExists {
 				if _, ok := m.gauges[pmk]; !ok {
 					m.gauges[pmk] = prometheus.NewGaugeVec(
 						prometheus.GaugeOpts{
 							Name:      pmk,
 							Namespace: "tasmota",
 						},
-						[]string{"source", "status_topic", "status_net_hostname", "status_device_name"},
+						[]string{"source", "status_topic", "status_net_hostname", "status_net_ip_address", "status_device_name"},
 					)
 					prometheus.MustRegister(m.gauges[pmk])
 				}
-				m.gauges[pmk].WithLabelValues(source, statusTopic, statusNetHostname, statusDeviceName).Set(float)
+				m.gauges[pmk].WithLabelValues(source, statusTopic, statusNetHostname, statusNetIpAddress, statusDeviceName).Set(float)
 			}
 		}
 	}


### PR DESCRIPTION
I'm using my own http server in go for prometheus-alertmanager to notify me about several plug state changes, but only when state really changed.

Unfortunately, in case telemetry data is missing, prometheus mark issue as resolved and send that information through alert manager to me. That is the reason I need device IP address in metric. To check back, if a device I got alert for is really not reachable on network (so telemetry data is missing) and ignore that particular alert.